### PR TITLE
Document -5 option in man page (bsc#955375)

### DIFF
--- a/man/sbd.8.pod
+++ b/man/sbd.8.pod
@@ -127,6 +127,12 @@ that it needed to self-fence.)
 
 This also affects the I<stonith-timeout> in Pacemaker's CIB; see below.
 
+=item B<-5> I<N>
+
+Warn if loop latency exceeds threshold (optional, watch only)
+
+(default is 3, set to 0 to disable)
+
 =back
 
 =head2 list


### PR DESCRIPTION
The `-5` option was documented in the `-h` output, but not in the man page.
